### PR TITLE
Fix README key generation and funding steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # chainflip-mainnet-apis
 
+> Terms of use: This repository is provided as-is for self-managed Chainflip infrastructure. You are responsible for securing your keys, validating configuration changes, and complying with any applicable Chainflip, network, and local legal requirements.
+
 ## Pre-requisites
 - Docker (https://docs.docker.com/get-docker/)
 - JQ (https://stedolan.github.io/jq/download/)
@@ -12,17 +14,33 @@ git clone https://github.com/chainflip-io/chainflip-mainnet-apis.git
 cd chainflip-mainnet-apis
 ```
 
+Official guides:
+- Broker Light RPC node: https://docs.chainflip.io/brokers/broker-light-rpc-node
+- LP Light RPC node: https://docs.chainflip.io/lp/lp-light-rpc-node
+
 ### Generating Keys
 
 > ⛔️ Please make sure you backup your keys. If you lose your keys, you will lose access to your funds. ⛔️
 
+If you already have an existing Broker or LP signing key, copy it to:
+- Broker: `./chainflip/keys/broker/signing_key_file`
+- LP: `./chainflip/keys/lp/signing_key_file`
+
+If you do not have existing keys, generate them with:
+
 ```bash
-mkdir -p ./chainflip/keys/lp
-mkdir -p ./chainflip/keys/broker
-docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli chainfliplabs/chainflip-cli:berghain-2.0.5
-docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli chainfliplabs/chainflip-cli:berghain-2.0.5
-cat chainflip/broker-keys.json | jq -r '.signing_key.secret_key' > chainflip/keys/broker/signing_key_file
-cat chainflip/lp-keys.json | jq -r '.signing_key.secret_key' > chainflip/keys/lp/signing_key_file
+mkdir -p ./chainflip/keys/lp ./chainflip/keys/broker
+
+docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli \
+  chainfliplabs/chainflip-cli:berghain-2.1.4 \
+  generate-keys --json > chainflip/lp-keys.json
+
+docker run --platform=linux/amd64 --entrypoint=/usr/local/bin/chainflip-cli \
+  chainfliplabs/chainflip-cli:berghain-2.1.4 \
+  generate-keys --json > chainflip/broker-keys.json
+
+jq -r '.signing_key.secret_key' chainflip/broker-keys.json > chainflip/keys/broker/signing_key_file
+jq -r '.signing_key.secret_key' chainflip/lp-keys.json > chainflip/keys/lp/signing_key_file
 ```
 
 ### Fund Accounts
@@ -39,76 +57,14 @@ cat chainflip/broker-keys.json | jq -r '.signing_account_id'
 cat chainflip/lp-keys.json | jq -r '.signing_account_id'
 ```
 
-2. Then head to the [Auctions Web App](https://auctions.chainflip.io/nodes)
-3. Connect your wallet
-4. Click "Add Node"
-5. Follow the instructions to fund the account
+2. Then head to the [Auctions Web App](https://auctions.chainflip.io/)
+3. Connect your wallet in MetaMask
+4. Click `Register Node`
+5. Paste the public key from above when prompted
+6. Approve `sFLIP` in your wallet (e.g. MetaMask) when prompted
+7. Add funds to that State Chain account to register it as a Broker or LP
 
-## 🚀 Migrating to RPC 2.0.5
-
-> ✨ **Upgrade Notice**: If you're upgrading from a previous version that used separate LP and Broker API services, RPC 2.0.5
-
-### 🔄 Key Changes
-- 🎯 **Consolidated APIs**: LP and Broker RPCs are now part of the node itself, eliminating the need for separate API containers
-- 🔑 **Key Injection**: Signing keys are automatically injected into the node's keystore on startup
-- 📋 **Profile-based Configuration**: Use Docker Compose profiles to run different node configurations
-
-### 📋 Migration Steps
-
-#### 🔐 **Important: Backup Your Private Keys**
-> ⚠️ **CRITICAL**: Before proceeding with the migration, ensure you have secure backups of all your private keys. Store backups in multiple secure locations (encrypted USB drives, secure cloud storage, etc.). If you lose your keys during migration, you will lose access to your funds permanently.
-
-#### 1️⃣ **Verify Key Location**
-> ✅ No changes needed if you followed the setup guide!
-
-Ensure your keys are in the correct location:
-- 🔐 Broker keys: `./chainflip/keys/broker/signing_key_file`
-- 🔐 LP keys: `./chainflip/keys/lp/signing_key_file`
-
-#### 2️⃣ **Update Docker Compose Commands**
-```bash
-# ❌ Old: separate services
-docker compose up node broker lp
-
-# ✅ New: profile-based approach
-docker compose --profile broker up -d    # For broker functionality
-docker compose --profile lp up -d        # For LP functionality
-docker compose --profile rpc-node up -d  # For basic RPC node
-```
-
-#### 3️⃣ **Safe Deployment Strategy**
-> 🛡️ **Zero-downtime migration**: Deploy the new setup alongside your existing deployment for a safe transition.
-
-**Recommended approach:**
-1. **Deploy in parallel**: Start the new RPC 2.0.5
-2. **Switch workloads**: Switch your applications to use the new endpoints
-3. **Verify functionality**: Ensure all your integrations work correctly with the new setup
-4. **Remove old deployment**: Once confident, stop and remove the old containers
-
-> ⚠️ Make sure that you only send LP or Broker API requests to one deployment at a time (old or new) assuming you are using the same account (signing key) for both deployments. Otherwise, you will get errors due to Nonce conflicts.
-
-```bash
-# Example: Run new setup on port 9945 while old setup uses 9944
-# Update docker-compose.yml ports temporarily:
-ports:
-  - "9945:9944"  # New setup on 9945
-
-# Test new setup
-curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
-    http://localhost:9945
-
-# Once verified, switch to standard port 9944 and remove old deployment
-```
-
-#### 4️⃣ **API Integration**
-> 🎉 **No code changes required!** Your existing integration continues to work unchanged.
-
-All API calls now point to: `http://localhost:9944`
-
----
-
-> 💡 **Drop-in Replacement**: The migration is designed as a seamless upgrade - once your signing keys are in the correct location, everything works with the new architecture!
+> Note: The `Min. Active Bid` shown in the Auctions app applies to validator bidding. It does not apply to Broker or LP registration. For Broker or LP accounts, you can proceed with the `Approve sFLIP` and funding steps.
 
 ### Running the APIs
 
@@ -120,7 +76,7 @@ All API calls now point to: `http://localhost:9944`
 > This can be achieved by removing the `127.0.0.1:` before the port number. For example:
 ```yaml
   node-with-lp:
-    image: chainfliplabs/chainflip-node:berghain-2.0.5
+    image: chainfliplabs/chainflip-node:berghain-2.1.4
     pull_policy: always
     stop_grace_period: 5s
     stop_signal: SIGINT
@@ -131,6 +87,7 @@ All API calls now point to: `http://localhost:9944`
       - "9944:9944" # <--- This is updated to accept connections from any host
     volumes:
       - ./chainflip/keys/lp:/etc/chainflip-keys/lp
+      - ./chainflip/chaindata:/etc/chainflip/chaindata
     entrypoint: /bin/sh
     command: >
       -c '
@@ -150,6 +107,7 @@ All API calls now point to: `http://localhost:9944`
         --sync=light-rpc \
         --blocks-pruning=128 \
         --state-pruning=128 \
+        --disable-log-color \
         --log info,grandpa=error,runtime::grandpa=off,aura=error,babe=error,txpool::api=error
       '
     profiles:
@@ -158,7 +116,12 @@ All API calls now point to: `http://localhost:9944`
 
 #### Starting the APIs
 
-> 💡 Note: As of version 1.9, the LP and Broker APIs binaries are deprecated. The LP and Broker RPCs are now integrated into the node itself. You only need to run a node and inject your LP key to enable LP RPCs or Broker key to enable broker RPCs.
+> 💡 Note: As of version `1.12.0`, the LP and Broker API binaries are deprecated. The LP and Broker RPCs are now integrated into the node itself. You only need to run a node and inject your LP key to enable LP RPCs or your Broker key to enable Broker RPCs.
+
+Recommended minimum resources for a light-RPC node:
+- 2 vCPU
+- 4 GB RAM
+- 20 GB SSD
 
 The docker-compose file is configured with three distinct profiles, each serving a specific purpose:
 - `rpc-node`: Basic RPC node without LP or Broker functionality
@@ -195,16 +158,18 @@ docker compose --profile lp logs -f
 
 > 💡 Note: Your node is considered synced when you see logs similar to:
 ```log
-chainflip-mainnet-apis-node-1  | 2023-12-14 10:22:24 ✨ Imported #438968 (0x3fba…8e06)
-chainflip-mainnet-apis-node-1  | 2023-12-14 10:22:28 ⏩ Block history, #26112 (8 peers), best: #438968 (0x3fba…8e06), finalized #438966 (0x99bd…0628), ⬇ 3.4MiB/s ⬆ 182.8kiB/s
+node-with-lp-1  | 2025-10-30 10:53:49 Imported #10260208 (0xe26d…ad53 → 0xc279…f190)
+node-with-lp-1  | 2025-10-30 10:53:54 Idle (8 peers), best: #10260208 (0xc279…f190), finalized #10260206 (0x0507…e82d), ⬇ 229.9kiB/s ⬆ 184.4kiB/s
 ```
 
-You can check the node's health and verified it is synced by using this RPC call:
+You can check the node's health and verify it is synced by using this RPC call:
 ```
 curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
+    -d '{"id":1, "jsonrpc":"2.0", "method": "system_health"}' \
     http://localhost:9944
 ```
+
+You should see `isSyncing` set to `false` in the response.
 
 ### Interacting with the APIs
 
@@ -217,7 +182,7 @@ Register a broker account:
 
 ```bash
 curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
+    -d '{"id":1, "jsonrpc":"2.0", "method": "broker_register_account"}' \
     http://localhost:9944
 ```
 
@@ -225,7 +190,7 @@ Request a swap deposit address:
 
 ```bash
 curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
+    -d '{"id":1, "jsonrpc":"2.0", "method": "broker_request_swap_deposit_address", "params": ["ETH", "FLIP","0xabababababababababababababababababababab", 0]}' \
     http://localhost:9944
 ```
 
@@ -235,7 +200,7 @@ Register an LP account:
 
 ```bash
 curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
+    -d '{"id":1, "jsonrpc":"2.0", "method": "lp_register_account", "params": [0]}' \
     http://localhost:9944
 ```
 Register a liquidity refund address:
@@ -244,7 +209,7 @@ Before you can deposit liquidity, you need to register a liquidity refund addres
 
 ```bash
 curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
+    -d '{"id":1, "jsonrpc":"2.0", "method": "lp_register_liquidity_refund_address", "params": {"chain": "Ethereum", "address": "0xabababababababababababababababababababab"}}' \
     http://localhost:9944
 
 ```
@@ -253,8 +218,80 @@ Request a liquidity deposit address:
 
 ```bash
 curl -H "Content-Type: application/json" \
-    -d '{"id":1, "jsonrpc":"2.0.5
+    -d '{"id":1, "jsonrpc":"2.0", "method": "lp_request_liquidity_deposit_address_v2", "params": ["ETH"]}' \
     http://localhost:9944
 ```
 
-For more details please refer to the [Integrations documentation](https://docs.chainflip.io/integration/liquidity-provision/lp-api).
+For more details, refer to the official docs:
+- Broker Light RPC node: https://docs.chainflip.io/brokers/broker-light-rpc-node
+- LP Light RPC node: https://docs.chainflip.io/lp/lp-light-rpc-node
+
+## 🚀 Migrating to `berghain-2.1.4`
+
+> ✨ **Upgrade Notice**: If you're upgrading from a previous version that used separate LP and Broker API services, use the current Docker images and commands from this repository.
+
+### 🔄 Key Changes
+- 🎯 **Consolidated APIs**: LP and Broker RPCs are now part of the node itself, eliminating the need for separate API containers
+- 🔑 **Key Injection**: Signing keys are automatically injected into the node's keystore on startup
+- 📋 **Profile-based Configuration**: Use Docker Compose profiles to run different node configurations
+
+### 📋 Migration Steps
+
+#### 🔐 **Important: Backup Your Private Keys**
+> ⚠️ **CRITICAL**: Before proceeding with the migration, ensure you have secure backups of all your private keys. Store backups in multiple secure locations (encrypted USB drives, secure cloud storage, etc.). If you lose your keys during migration, you will lose access to your funds permanently.
+
+#### 1️⃣ **Verify Key Location**
+> ✅ No changes needed if you followed the setup guide!
+
+Ensure your keys are in the correct location:
+- 🔐 Broker keys: `./chainflip/keys/broker/signing_key_file`
+- 🔐 LP keys: `./chainflip/keys/lp/signing_key_file`
+
+#### 2️⃣ **Update Docker Compose Commands**
+```bash
+# ❌ Old: separate services
+docker compose up node broker lp
+
+# ✅ New: profile-based approach
+docker compose --profile broker up -d    # For broker functionality
+docker compose --profile lp up -d        # For LP functionality
+docker compose --profile rpc-node up -d  # For basic RPC node
+```
+
+#### 3️⃣ **Safe Deployment Strategy**
+> 🛡️ **Zero-downtime migration**: Deploy the new setup alongside your existing deployment for a safe transition.
+
+**Recommended approach:**
+1. **Deploy in parallel**: Start the new deployment
+2. **Switch workloads**: Switch your applications to use the new endpoints
+3. **Verify functionality**: Ensure all your integrations work correctly with the new setup
+4. **Remove old deployment**: Once confident, stop and remove the old containers
+
+> ⚠️ Make sure that you only send LP or Broker API requests to one deployment at a time (old or new) assuming you are using the same account (signing key) for both deployments. Otherwise, you will get errors due to Nonce conflicts.
+
+```bash
+# Example: Run new setup on port 9945 while old setup uses 9944
+# Update docker-compose.yml ports temporarily:
+ports:
+  - "9945:9944"  # New setup on 9945
+
+# Test new setup
+curl -H "Content-Type: application/json" \
+    -d '{"id":1, "jsonrpc":"2.0", "method": "system_health"}' \
+    http://localhost:9945
+
+# Once verified, switch to standard port 9944 and remove old deployment
+```
+
+#### 4️⃣ **API Integration**
+> 🎉 **No code changes required!** Your existing integration continues to work unchanged.
+
+All API calls now point to: `http://localhost:9944`
+
+For official migration details:
+- Broker: https://docs.chainflip.io/brokers/broker-light-rpc-node#migrating-from-broker-api-binary
+- LP: https://docs.chainflip.io/lp/lp-light-rpc-node#migrating-from-lp-api-binary
+
+---
+
+> 💡 **Drop-in Replacement**: The migration is designed as a seamless upgrade - once your signing keys are in the correct location, everything works with the new architecture!


### PR DESCRIPTION
- Correct key generation commands
- Refresh Docker image/version references to berghain-2.1.4 and aligns examples with the current node behavior
- Improve funding/registration instructions in Auctions (wallet connect, register node, approve sFLIP, fund State Chain account) and clarifies that validator min bid does not apply to Broker/LP registration
- Fix JSON-RPC curl examples
- Move Migration guide at the end